### PR TITLE
Fix: user-agent includes "silk"

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -38,6 +38,15 @@ describe('Middleware', () => {
       });
     });
 
+    it('Slider.com Crawler UA', done => {
+      const fn = expressBot();
+      request.headers['user-agent'] = 'Silk/1.0 (+https://www.slider.com/silk.htm)';
+      fn(request, response, () => {
+        expect(response.locals.bot).toBeTruthy();
+        done();
+      });
+    });
+
     it('Set arguments(options)', done => {
       const fn = expressBot({
         querystring: {
@@ -168,6 +177,15 @@ describe('Middleware', () => {
         additionalBots: ['MinorBot'],
       });
       request.headers['user-agent'] = 'no-bot';
+      fn(request, response, () => {
+        expect(response.locals.bot).toBeFalsy();
+        done();
+      });
+    });
+
+    it('Fire-Tablet (Silk Browser) UA', done => {
+      const fn = expressBot({});
+      request.headers['user-agent'] = 'Mozilla/5.0 (Linux; Android 9; KFMAWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.3.1 like Chrome/90.0.4430.210 Safari/537.36';
       fn(request, response, () => {
         expect(response.locals.bot).toBeFalsy();
         done();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-bot",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-bot",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Crawler(robots) decision middleware for Express",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ const BOTS: string[] = [
   'truwoGPS',
   'StackRambler',
   'Sqworm',
-  'silk',
+  'silk\\.htm',
   'semanticdiscovery',
   'ScoutJet',
   'Nymesis',


### PR DESCRIPTION
"silk" という文字列がAmazonFireタブレット内蔵ブラウザのUAにも入っているため、ボット判定されないように調整しました。

AmazonFireタブレットのUA
```
Mozilla/5.0 (Linux; Android 9; KFMAWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.3.1 like Chrome/90.0.4430.210 Safari/537.36
```

元々弾きたかったslider.comのクローラーのUA
```
Silk/1.0 (+https://www.slider.com/silk.htm)
```